### PR TITLE
Exception while running display

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ output:
     │──3. func2
 ```
 
-Or get more detailed data about invoked objects (-d="detailed_data"):
+(If some exception was raised while tracing, the broken object will appear write in red color.)
+
+Get more detailed data about invoked objects (-d="detailed_data"):
 ```
  outliner --file_path=path-to-module --object_name=test -d="detailed_data"
 ```

--- a/src/outliner/modules/display.py
+++ b/src/outliner/modules/display.py
@@ -15,12 +15,15 @@ class Display:
             "VERTICAL_LINE": "\u2502",
             "Regular_line": "\u2500",
             "CHILD_OBJECT_ANSI": "\033[36m",
+            "CHILD_WITH_EXECEPTION": "\033[31m",
         }
 
     def tree(self):
         position = 0
 
         for i in self.functions_flow:
+            func_With_exception = bool(self.detail_data[i].get("exception"))
+
             connector_root = (
                 "    "
                 + self.ansi_for_tree["MAIN_OBJECT_ANSI"]
@@ -35,7 +38,11 @@ class Display:
             )
             connect_branch = (
                 lines
-                + self.ansi_for_tree["CHILD_OBJECT_ANSI"]
+                + self.ansi_for_tree[
+                    "CHILD_OBJECT_ANSI"
+                    if not func_With_exception
+                    else "CHILD_WITH_EXECEPTION"
+                ]
                 + f"{position}. "
                 + i
                 + "\n"

--- a/src/outliner/modules/trace.py
+++ b/src/outliner/modules/trace.py
@@ -3,46 +3,53 @@ import collections
 import importlib.util
 
 
+class ExceptionWhileTracing(Exception):
+    """Exception Subclass to be raise with the first exception while tracing an object"""
+
+    pass
+
+
 class Trace:
     def __init__(self):
         self.detailed_data = collections.defaultdict(
-            lambda: {"call": 0, "return": 0, "line": 0}
+            lambda: {"call": 0, "return": 0, "line": 0, "exception": 0}
         )
         self.functions_flow = collections.OrderedDict()
 
     def _trace_function(self, frame, event, arg):
         self.detailed_data[frame.f_code.co_name][str(event)] += 1
         self.functions_flow[frame.f_code.co_name] = None
+
+        if str(event) == "exception":
+            raise ExceptionWhileTracing()
+
         return self._trace_function
 
-    def run_file(self, module_name: str, func: str, func_params=None):
-        try:
-            trace_import = importlib.util.spec_from_file_location(func, module_name)
-            trace_obj = importlib.util.module_from_spec(trace_import)
-            trace_import.loader.exec_module(trace_obj)
-
-            object_to_run = getattr(trace_obj, func, None)
-
-            if not callable(object_to_run):
-                raise Exception("given object '%s' is not callable." % (func))
-
-            if func_params:
-                self._running_trace(object_to_run, *func_params)
-            else:
-                self._running_trace(object_to_run)
-
-        except Exception as e:
-            raise Exception("Error on the execution of the module: \n %s" % (e))
-
     def _running_trace(self, obj, *arguments):
-        if arguments:
+        try:
             sys.settrace(self._trace_function)
-            obj(*arguments)
+            obj() if not arguments else obj(*arguments)
+        except ExceptionWhileTracing as error:
+            return
+        except Exception as error:
+            raise error
+        finally:
             sys.settrace(None)
+
+    def run_file(self, module_name: str, func: str, func_params=None):
+        trace_import = importlib.util.spec_from_file_location(func, module_name)
+        trace_obj = importlib.util.module_from_spec(trace_import)
+        trace_import.loader.exec_module(trace_obj)
+
+        object_to_run = getattr(trace_obj, func, None)
+
+        if not callable(object_to_run):
+            raise Exception("given object '%s' is not callable." % (func))
+
+        if func_params:
+            self._running_trace(object_to_run, *func_params)
         else:
-            sys.settrace(self._trace_function)
-            obj()
-            sys.settrace(None)
+            self._running_trace(object_to_run)
 
     def __str__(self):
         text = "Trace object\nrunned objects:\n    "

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -21,6 +21,17 @@ detail_data = collections.defaultdict(
     },
 )
 
+detail_data_with_exception = collections.defaultdict(
+    int,
+    {
+        "test2": {"call": 1, "return": 1, "line": 2},
+        "__init__": {"call": 1, "return": 1, "line": 1},
+        "func1": {"call": 1, "return": 1, "line": 2},
+        "func2": {"call": 1, "return": 1, "line": 1, "exception": 1},
+    },
+)
+
+
 class TestDisplay(unittest.TestCase):
     def setUp(self):
         self.parser = Display(detail_data, functions_flow)
@@ -50,4 +61,12 @@ class TestDisplay(unittest.TestCase):
     def test_detailed_data_negative_input(self, stdout, module):
         module_instance = module({}, {})
         module_instance.detailed_data()
+        self.assertEqual("", stdout.getvalue())
+
+    @patch("src.outliner.Display")
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_func_with_exception(self, stdout, module):
+        expected_result = "    \x1b[38;5;208mtest2\x1b[0m\n    │\n    │──\x1b[36m1. __init__\n\x1b[0m    │\n    │──\x1b[36m2. func1\n\x1b[0m    │\n    │──\x1b[33m3. func2\n\x1b[0m"
+        module_instance = module()
+        module_instance.tree()
         self.assertEqual("", stdout.getvalue())

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -55,7 +55,9 @@ class TestTrace(unittest.TestCase):
         """
         with self.assertRaises(Exception) as error:
             self.parser.run_file("not_valid_path", "object")
-        self.assertTrue("Error on the execution of the module" in str(error.exception))
+        self.assertTrue(
+            "'NoneType' object has no attribute 'loader" in str(error.exception)
+        )
 
     def test_trace_run_file_file_negative_non_callable_object(self):
         """


### PR DESCRIPTION
The current code does not show which callable object is broken while tracing. With this update it will mark the broken object in red in the tree display, making it better to visualize where it broke.

- [x] Update unit tests
- [x] Documentation  